### PR TITLE
External API simplified.

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -285,7 +285,7 @@ module Fleece =
 
 
         let inline iFromJSON (a: ^a, b: ^b) =
-            ((^a or ^b) : (static member FromJSON: ^b -> (JsonValue -> ^b ParseResult)) b)
+            ((^a or ^b) : (static member FromJSON: ^b*_ -> (JsonValue -> ^b ParseResult)) b, a)
 
         let inline iToJSON (a: ^a, b: ^b) =
             ((^a or ^b) : (static member ToJSON: ^b -> JsonValue) b)
@@ -311,31 +311,31 @@ module Fleece =
 
     type FromJSONClass = FromJSONClass with
         
-        static member FromJSON (_: bool) = 
+        static member FromJSON (_: bool, FromJSONClass) = 
             function
             | JBool b -> Success b
             | a -> failparse "bool" a
 
-        static member FromJSON (_: string) =
+        static member FromJSON (_: string, FromJSONClass) =
             function
             | JString b -> Success b
             | JNull -> Success null
             | a -> failparse "string" a
 
-        static member FromJSON (_: JsonObject) = JsonHelpers.jsonObjectFromJSON
-        static member FromJSON (_:decimal) = JsonHelpers.tryReadDecimal        
-        static member FromJSON (_:int16) = JsonHelpers.tryReadInt16
-        static member FromJSON (_:int) = JsonHelpers.tryReadInt        
-        static member FromJSON (_:int64) = JsonHelpers.tryReadInt64                
-        static member FromJSON (_:uint16) = JsonHelpers.tryReadUInt16
-        static member FromJSON (_:uint32) = JsonHelpers.tryReadUInt32
-        static member FromJSON (_:uint64) = JsonHelpers.tryReadUInt64
-        static member FromJSON (_:byte) = JsonHelpers.tryReadByte
-        static member FromJSON (_:sbyte) = JsonHelpers.tryReadSByte
-        static member FromJSON (_:double) = JsonHelpers.tryReadDouble
-        static member FromJSON (_:single) = JsonHelpers.tryReadSingle
+        static member FromJSON (_: JsonObject, FromJSONClass) = JsonHelpers.jsonObjectFromJSON
+        static member FromJSON (_:decimal, FromJSONClass) = JsonHelpers.tryReadDecimal        
+        static member FromJSON (_:int16, FromJSONClass) = JsonHelpers.tryReadInt16
+        static member FromJSON (_:int, FromJSONClass) = JsonHelpers.tryReadInt        
+        static member FromJSON (_:int64, FromJSONClass) = JsonHelpers.tryReadInt64                
+        static member FromJSON (_:uint16, FromJSONClass) = JsonHelpers.tryReadUInt16
+        static member FromJSON (_:uint32, FromJSONClass) = JsonHelpers.tryReadUInt32
+        static member FromJSON (_:uint64, FromJSONClass) = JsonHelpers.tryReadUInt64
+        static member FromJSON (_:byte, FromJSONClass) = JsonHelpers.tryReadByte
+        static member FromJSON (_:sbyte, FromJSONClass) = JsonHelpers.tryReadSByte
+        static member FromJSON (_:double, FromJSONClass) = JsonHelpers.tryReadDouble
+        static member FromJSON (_:single, FromJSONClass) = JsonHelpers.tryReadSingle
 
-        static member FromJSON (_: char) =
+        static member FromJSON (_: char, FromJSONClass) =
             function
             | JString s -> 
                 if s = null
@@ -343,7 +343,7 @@ module Fleece =
                     else Success s.[0]
             | a -> failparse "char" a
 
-        static member FromJSON (_: Guid) =
+        static member FromJSON (_: Guid, FromJSONClass) =
             function
             | JString s -> 
                 if s = null
@@ -354,7 +354,7 @@ module Fleece =
                         | true, g -> Success g
             | a -> failparse "Guid" a
 
-        static member FromJSON (_: DateTime) =
+        static member FromJSON (_: DateTime, FromJSONClass) =
             function
             | JString s ->
                 if s = null 
@@ -364,7 +364,7 @@ module Fleece =
                          | _ -> Failure (sprintf "Invalid DateTime %s" s)
             | a -> failparse "DateTime" a
 
-        static member FromJSON (_: DateTimeOffset) =
+        static member FromJSON (_: DateTimeOffset, FromJSONClass) =
             function
             | JString s ->
                 if s = null 
@@ -398,7 +398,7 @@ module Fleece =
         | _ -> Success None
 
     type FromJSONClass with
-        static member inline FromJSON (_: Choice<'a, 'b>) : JsonValue -> ParseResult<Choice<'a, 'b>> =
+        static member inline FromJSON (_: Choice<'a, 'b>, FromJSONClass) : JsonValue -> ParseResult<Choice<'a, 'b>> =
             function
             | JObject o as jobj ->
                 match Seq.toList o with
@@ -408,7 +408,7 @@ module Fleece =
             | a -> failparse "Choice" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: Choice<'a, 'b, 'c>) : JsonValue -> ParseResult<Choice<'a, 'b, 'c>> =
+        static member inline FromJSON (_: Choice<'a, 'b, 'c>, FromJSONClass) : JsonValue -> ParseResult<Choice<'a, 'b, 'c>> =
             function
             | JObject o as jobj ->
                 match Seq.toList o with
@@ -419,7 +419,7 @@ module Fleece =
             | a -> failparse "Choice" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a option) : JsonValue -> ParseResult<'a option> =
+        static member inline FromJSON (_: 'a option, FromJSONClass) : JsonValue -> ParseResult<'a option> =
             function
             | JNull a -> Success None
             | x -> 
@@ -427,7 +427,7 @@ module Fleece =
                 map Some a
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a Nullable) : JsonValue -> ParseResult<'a Nullable> =
+        static member inline FromJSON (_: 'a Nullable, FromJSONClass) : JsonValue -> ParseResult<'a Nullable> =
             function
             | JNull a -> Success (Nullable())
             | x -> 
@@ -435,7 +435,7 @@ module Fleece =
                 map (fun x -> Nullable x) a
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a array) : JsonValue -> ParseResult<'a array> =
+        static member inline FromJSON (_: 'a array, FromJSONClass) : JsonValue -> ParseResult<'a array> =
             function
             | JArray a -> 
                 let xx : 'a seq ParseResult = traverse fromJSON a 
@@ -443,7 +443,7 @@ module Fleece =
             | a -> failparse "array" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: list<'a>) : JsonValue -> ParseResult<list<'a>> =
+        static member inline FromJSON (_: list<'a>, FromJSONClass) : JsonValue -> ParseResult<list<'a>> =
             function
             | JArray a -> 
                 let xx : 'a seq ParseResult = traverse fromJSON a
@@ -451,7 +451,7 @@ module Fleece =
             | a -> failparse "array" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a Set) : JsonValue -> ParseResult<'a Set> =
+        static member inline FromJSON (_: 'a Set, FromJSONClass) : JsonValue -> ParseResult<'a Set> =
             function
             | JArray a -> 
                 let xx : 'a seq ParseResult = traverse fromJSON a
@@ -459,7 +459,7 @@ module Fleece =
             | a -> failparse "array" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: Map<string, 'a>) : JsonValue -> ParseResult<Map<string, 'a>> =
+        static member inline FromJSON (_: Map<string, 'a>, FromJSONClass) : JsonValue -> ParseResult<Map<string, 'a>> =
             function
             | JObject o as jobj ->
                 let xx : 'a seq ParseResult = traverse fromJSON (values o)
@@ -467,7 +467,7 @@ module Fleece =
             | a -> failparse "Map" a
 
     type FromJSONClass with
-        static member inline FromJSON (_: Dictionary<string, 'a>) : JsonValue -> ParseResult<Dictionary<string, 'a>> =
+        static member inline FromJSON (_: Dictionary<string, 'a>, FromJSONClass) : JsonValue -> ParseResult<Dictionary<string, 'a>> =
             function
             | JObject o as jobj ->
                 let xx : 'a seq ParseResult = traverse fromJSON (values o)
@@ -478,17 +478,17 @@ module Fleece =
                         d)
             | a -> failparse "Dictionary" a
 
-        static member inline FromJSON (_: 'a ResizeArray) : JsonValue -> ParseResult<'a ResizeArray> =
+        static member inline FromJSON (_: 'a ResizeArray, FromJSONClass) : JsonValue -> ParseResult<'a ResizeArray> =
             function
             | JArray a -> 
                 let xx : 'a seq ParseResult = traverse fromJSON a
                 map (fun x -> ResizeArray<_>(x: 'a seq)) xx
             | a -> failparse "ResizeArray" a
 
-        static member inline FromJSON (_: 'a Id) : JsonValue -> ParseResult<Id<'a>> = fun _ -> Success (Id<'a>(Unchecked.defaultof<'a>))
+        static member inline FromJSON (_: 'a Id, FromJSONClass) : JsonValue -> ParseResult<Id<'a>> = fun _ -> Success (Id<'a>(Unchecked.defaultof<'a>))
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b) : JsonValue -> ParseResult<'a * 'b> =
+        static member inline FromJSON (_: 'a * 'b, FromJSONClass) : JsonValue -> ParseResult<'a * 'b> =
             function
             | JArray a as x ->
                 if a.Count <> 2 then
@@ -498,7 +498,7 @@ module Fleece =
             | a -> Failure (sprintf "Expected array, found %A" a)
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b * 'c) : JsonValue -> ParseResult<'a * 'b * 'c> =
+        static member inline FromJSON (_: 'a * 'b * 'c, FromJSONClass) : JsonValue -> ParseResult<'a * 'b * 'c> =
             function
             | JArray a as x ->
                 if a.Count <> 3 then
@@ -508,7 +508,7 @@ module Fleece =
             | a -> Failure (sprintf "Expected array, found %A" a)
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b * 'c * 'd) : JsonValue -> ParseResult<'a * 'b * 'c * 'd> =
+        static member inline FromJSON (_: 'a * 'b * 'c * 'd, FromJSONClass) : JsonValue -> ParseResult<'a * 'b * 'c * 'd> =
             function
             | JArray a as x ->
                 if a.Count <> 4 then
@@ -518,7 +518,7 @@ module Fleece =
             | a -> Failure (sprintf "Expected array, found %A" a)
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e> =
+        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e, FromJSONClass) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e> =
             function
             | JArray a as x ->
                 if a.Count <> 5 then
@@ -528,7 +528,7 @@ module Fleece =
             | a -> Failure (sprintf "Expected array, found %A" a)
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e * 'f) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e * 'f> =
+        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e * 'f, FromJSONClass) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e * 'f> =
             function
             | JArray a as x ->
                 if a.Count <> 6 then
@@ -538,7 +538,7 @@ module Fleece =
             | a -> Failure (sprintf "Expected array, found %A" a)
 
     type FromJSONClass with
-        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e * 'f * 'g) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e * 'f * 'g> =
+        static member inline FromJSON (_: 'a * 'b * 'c * 'd * 'e * 'f * 'g, FromJSONClass) : JsonValue -> ParseResult<'a * 'b * 'c * 'd * 'e * 'f * 'g> =
             function
             | JArray a as x ->
                 if a.Count <> 7 then
@@ -546,6 +546,11 @@ module Fleece =
                 else
                     tuple7 <!> (fromJSON a.[0]) <*> (fromJSON a.[1]) <*> (fromJSON a.[2]) <*> (fromJSON a.[3]) <*> (fromJSON a.[4]) <*> (fromJSON a.[5]) <*> (fromJSON a.[6])
             | a -> Failure (sprintf "Expected array, found %A" a)
+
+    // Default, for external classes.
+    type FromJSONClass with 
+        static member inline FromJSON (r:'R, _:obj                             ) = (^R : (static member FromJSON: ^R   -> (JsonValue -> ^R ParseResult)) r ) : JsonValue ->  ^R ParseResult
+        static member inline FromJson (_:'R, _:Collections.IStructuralEquatable) = fun js -> (^R : (static member FromJSON: JsonValue -> ^R ParseResult) js) : ^R ParseResult
 
     // Serializing:
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ And you can map it from JSON like this:
 
 ```fsharp
 type Person with
-    static member FromJSON (_: Person) =
-        function
+    static member FromJSON json =
+        match json with
         | JObject o ->
             let name = o .@ "name"
             let age = o .@ "age"
@@ -83,8 +83,8 @@ open FSharpPlus
 type Person with
     static member Create name age children = { Person.Name = name; Age = age; Children = children }
 
-    static member FromJSON (_: Person) =
-        function
+    static member FromJSON json =
+        match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
         | x -> Failure (sprintf "Expected person, found %A" x)
 
@@ -95,8 +95,8 @@ Or monadically:
 
 ```fsharp
 type Person with
-    static member FromJSON (_: Person) = 
-        function
+    static member FromJSON json =
+        match json with
         | JObject o -> 
             monad {
                 let! name = o .@ "name"

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -23,8 +23,8 @@ type Person = {
 type Person with
     static member Create name age children = { Person.Name = name; Age = age; Children = children }
 
-    static member FromJSON (_: Person) = 
-        function
+    static member FromJSON json = 
+        match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
         | x -> Failure (sprintf "Expected person, found %A" x)
 
@@ -69,8 +69,8 @@ type Item = {
 }
 
 type Item with
-    static member FromJSON (_: Item) =
-        function
+    static member FromJSON json =
+        match json
         | JObject o ->
             monad {
                 let! id = o .@ "id"
@@ -87,8 +87,8 @@ type Item with
 type NestedItem = NestedItem of Item
 
 type NestedItem with
-    static member FromJSON (_: NestedItem) =
-        function
+    static member FromJSON json =
+        match json
         | JObject o ->
             monad {
                 let! id = o .@ "id"


### PR DESCRIPTION
Have a look, I did this already for many common abstractions in [FSharpPlus](https://github.com/gusty/FSharpPlus).
Clean signatures increase the chance someone will adopt it thinking that for the same price it will be compatible with Fleece, or even without having it in mind at all.
For Fleece the method <code>FromJSON</code> will change, it will no longer need the dummy parameter.
The drawback is that it's not backward compatible but I think it worths. But if you want another default overload can be added to become backward compatible.
