### PR TITLE
Lock System.Json

### DIFF
--- a/Fleece/Fleece.fsproj
+++ b/Fleece/Fleece.fsproj
@@ -32,6 +32,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharpPlus" Version="1.0.0" />
-    <PackageReference Include="System.Json" Version="4.0.20126.16343" />
+    <PackageReference Include="System.Json" Version="[4.0.20126.16343]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The latest System.Json is incompatible, so lock to the exact version this is using in the nuget package