### PR TITLE
Bugfix for erroneous wrapping of Newtonsoft.Linq.JObject

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -97,7 +97,12 @@ module Fleece =
         x |> Seq.map (|KeyValue|) |> Array.ofSeq 
 
     let inline JArray (x: JToken IReadOnlyList) = JArray (x |> Array.ofSeq) :> JToken
-    let inline JObject (x: IReadOnlyDictionary<string, JToken>) = JObject (dictAsProps x) :> JToken
+    let inline JObject (x: IReadOnlyDictionary<string, JToken>) 
+        =
+        let o = JObject()
+        for kv in x do
+            o.Add(kv.Key, kv.Value)
+        o :> JToken
     let inline JBool (x: bool) = JValue x :> JToken
     let JNull = JValue.CreateNull() :> JToken
     let inline JString (x: string) = if isNull x then JNull else JValue x :> JToken

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -199,23 +199,53 @@ let tests =
             }
 
             test "tuple 2" {
-                Assert.JSON("[1,2]", (1,2))
+                let expected = 
+                #if NEWTONSOFT
+                    "[1.0,2.0]"
+                #else
+                    "[1,2]"
+                #endif
+                Assert.JSON(expected, (1,2))
             }
 
             test "DateTime" {
-                Assert.JSON("\"2000-03-01T16:23:34.000Z\"", DateTime(2000, 3, 1, 16, 23, 34))
+                let expected = 
+                #if NEWTONSOFT
+                    "2000-03-01T16:23:34.000Z"
+                #else
+                    "\"2000-03-01T16:23:34.000Z\""
+                #endif
+                Assert.JSON(expected, DateTime(2000, 3, 1, 16, 23, 34))
             }
 
             test "DateTime with milliseconds" {
-                Assert.JSON("\"2000-03-01T16:23:34.123Z\"", DateTime(2000, 3, 1, 16, 23, 34, 123))
+                let expected = 
+                #if NEWTONSOFT
+                    "2000-03-01T16:23:34.123Z"
+                #else
+                    "\"2000-03-01T16:23:34.123Z\""
+                #endif
+                Assert.JSON(expected, DateTime(2000, 3, 1, 16, 23, 34, 123))
             }
 
             test "DateTimeOffset" {
-                Assert.JSON("\"2000-03-01T16:23:34.000+03:00\"", DateTimeOffset(2000, 3, 1, 16, 23, 34, TimeSpan(3, 0, 0)))
+                let expected = 
+                #if NEWTONSOFT
+                    "2000-03-01T16:23:34.000+03:00"
+                #else
+                    "\"2000-03-01T16:23:34.000+03:00\""
+                #endif
+                Assert.JSON(expected, DateTimeOffset(2000, 3, 1, 16, 23, 34, TimeSpan(3, 0, 0)))
             }
 
             test "DateTimeOffset with milliseconds" {
-                Assert.JSON("\"2000-03-01T16:23:34.078+03:00\"", DateTimeOffset(2000, 3, 1, 16, 23, 34, 78, TimeSpan(3, 0, 0)))
+                let expected = 
+                #if NEWTONSOFT
+                    "2000-03-01T16:23:34.078+03:00"
+                #else
+                    "\"2000-03-01T16:23:34.078+03:00\""
+                #endif
+                Assert.JSON(expected, DateTimeOffset(2000, 3, 1, 16, 23, 34, 78, TimeSpan(3, 0, 0)))
             }
 
             test "Person" {
@@ -231,7 +261,13 @@ let tests =
                           Age = 7
                           Children = [] }
                       ] }
-                Assert.JSON("""{"name":"John","age":44,"children":[{"name":"Katy","age":5,"children":[]},{"name":"Johnny","age":7,"children":[]}]}""", p)
+                let expected = 
+                #if NEWTONSOFT
+                    """{"name":"John","age":44.0,"children":[{"name":"Katy","age":5.0,"children":[]},{"name":"Johnny","age":7.0,"children":[]}]}"""
+                #else
+                    """{"name":"John","age":44,"children":[{"name":"Katy","age":5,"children":[]},{"name":"Johnny","age":7,"children":[]}]}"""
+                #endif
+                Assert.JSON(expected, p)
             }
 
             test "Map with null key" {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,3 +6,4 @@ build_script:
 test_script:
   - dotnet run --project .\Tests\Tests.fsproj --framework net461
   - dotnet run --project .\Tests.FSharpData\Tests.FSharpData.fsproj --framework net461
+  - dotnet run --project .\Tests.NewtonsoftJson\Tests.NewtonsoftJson.fsproj --framework net461


### PR DESCRIPTION
- The constructor of `Newtonsoft.Linq.JObject` does not accept a key value pair array
- Some of the Json is generated OK, but is slightly different from `FSharp.Data` and `System.Json`