### PR TITLE
Moving Success and Failure to Helpers

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -251,22 +251,14 @@ module SystemJson =
     let inline JNumber (x: decimal) = JsonPrimitive x :> JsonValue
     #endif
 
-
-    // results:
-
-    let (|Success|Failure|) =
-        function
-        | Ok    x -> Success x
-        | Error x -> Failure x
-
-    let inline Success x = Ok    x
-    let inline Failure x = Error x
-
     // Deserializing:
 
     type 'a ParseResult = Result<'a, string>
 
     module Helpers =
+        // results:
+        let inline Success x = Ok    x
+        let inline Failure x = Error x
 
         let inline failparse s v = Failure (sprintf "Expected %s, actual %A" s v)
 

--- a/IntegrationCompilationTests/Library.fs
+++ b/IntegrationCompilationTests/Library.fs
@@ -20,7 +20,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonSystemJson.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Failure (sprintf "Expected person, found %A" x)
+        | x -> Error (sprintf "Expected person, found %A" x)
 
     static member ToJson (x: PersonSystemJson) =
         jobj [ 
@@ -43,7 +43,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonFSharpData.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Failure (sprintf "Expected person, found %A" x)
+        | x -> Error (sprintf "Expected person, found %A" x)
 
     static member ToJson (x:PersonFSharpData) =
         jobj [ 
@@ -66,7 +66,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonNewtonsoft.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Failure (sprintf "Expected person, found %A" x)
+        | x -> Error (sprintf "Expected person, found %A" x)
 
     static member ToJson (x:PersonNewtonsoft) =
         jobj [ 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -7,20 +7,26 @@ open FSharpPlus
 
 #if FSHARPDATA
 open FSharp.Data
+open Fleece.FSharpData.Helpers
 open Fleece.FSharpData
 open Fleece.FSharpData.Operators
 #endif
 #if SYSTEMJSON
+open Fleece.SystemJson.Helpers
 open Fleece.SystemJson
 open Fleece.SystemJson.Operators
 open System.Json
 #endif
 #if NEWTONSOFT
 open Newtonsoft.Json
+open Fleece.Newtonsoft.Helpers
 open Fleece.Newtonsoft
 open Fleece.Newtonsoft.Operators
 #endif
-
+let (|Success|Failure|) =
+    function
+    | Ok    x -> Success x
+    | Error x -> Failure x
 #nowarn "0686"
 
 type Person = {


### PR DESCRIPTION
This should ensure that there are no accidental clashes between F#+ Validation
This fixes #43