### PR TITLE
Decode errors as DU

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -268,7 +268,7 @@ module SystemJson =
             let inline numExpected  v : Result<'t, _> = let a = getJType v in Error (JsonTypeMismatch (typeof<'t>, v, JType.Number, a))
             let inline strExpected  v : Result<'t, _> = let a = getJType v in Error (JsonTypeMismatch (typeof<'t>, v, JType.String, a))
             let inline boolExpected v : Result<'t, _> = let a = getJType v in Error (JsonTypeMismatch (typeof<'t>, v, JType.Bool  , a))
-            let nullString () : Result<'t, _> = Error (NullString typeof<'t>)
+            let [<GeneralizableValue>]nullString<'t> : Result<'t, _> = Error (NullString typeof<'t>)
             let inline count e a = Error (IndexOutOfRange (e, a))
             let invalidValue v o : Result<'t, _> = Error (InvalidValue (typeof<'t>, v, o))
             let propertyNotFound p o = Error (PropertyNotFound (p, o))
@@ -493,19 +493,19 @@ module SystemJson =
 
         let char x =
             match x with
-            | JString null -> FailDecode.nullString ()
+            | JString null -> FailDecode.nullString
             | JString s    -> Success s.[0]
             | a -> FailDecode.strExpected a
 
         let guid x =
             match x with
-            | JString null -> FailDecode.nullString ()
+            | JString null -> FailDecode.nullString
             | JString s    -> tryParse<Guid> s |> Operators.option Success (FailDecode.invalidValue x None)
             | a -> FailDecode.strExpected a
 
         let dateTime x =
             match x with
-            | JString null -> FailDecode.nullString ()
+            | JString null -> FailDecode.nullString
             | JString s    ->
                 match DateTime.TryParseExact (s, [| "yyyy-MM-ddTHH:mm:ss.fffZ"; "yyyy-MM-ddTHH:mm:ssZ" |], null, DateTimeStyles.RoundtripKind) with
                 | true, t -> Success t
@@ -514,7 +514,7 @@ module SystemJson =
 
         let dateTimeOffset x =
             match x with
-            | JString null -> FailDecode.nullString ()
+            | JString null -> FailDecode.nullString
             | JString s    ->
                 match DateTimeOffset.TryParseExact (s, [| "yyyy-MM-ddTHH:mm:ss.fffK"; "yyyy-MM-ddTHH:mm:ssK" |], null, DateTimeStyles.RoundtripKind) with
                 | true, t -> Success t

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -236,8 +236,13 @@ module SystemJson =
         | InvalidValue of System.Type * JsonValue * option<string>
         | PropertyNotFound of string * IReadOnlyDictionary<string, JsonValue>
         | ParseError of System.Type * exn * string
+        | Multiple of DecodeError list
 
     with
+        static member (+) (x, y) = 
+            match x, y with
+            | Multiple x, Multiple y -> Multiple (x @ y)
+            | _                      -> Multiple [x; y]
         override x.ToString () =
             match x with
             | JsonTypeMismatch (t, v: JsonValue, expected, actual) -> sprintf "%s expected but got %s while decoding %s as %s" (string expected) (string actual) (string v) (string t)
@@ -246,6 +251,7 @@ module SystemJson =
             | InvalidValue (t, v, s) -> sprintf "Value %s is invalid for %s%s" (string v) (string t) (s |> Option.map (fun x -> " " + x) |> Option.defaultValue "")
             | PropertyNotFound (p, o) -> sprintf "Property: '%s' not found in object '%s'" p (string o)
             | ParseError (t, s, v) -> sprintf "Error decoding %s from  %s: %s" (string v) (string t) (string s)
+            | Multiple lst -> List.map string lst |> String.concat "\r\n"
 
     type 'a ParseResult = Result<'a, DecodeError>
 

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -14,7 +14,9 @@ type Id2<'t> (v: 't) =
     let value = v
     member __.getValue = value
 
-type Default4 = class end
+type Default6 = class end
+type Default5 = class inherit Default6 end
+type Default4 = class inherit Default5 end
 type Default3 = class inherit Default4 end
 type Default2 = class inherit Default3 end
 type Default1 = class inherit Default2 end
@@ -674,12 +676,12 @@ module SystemJson =
 
     // Default, for external classes.
     type OfJson with 
-        static member inline OfJson (_: 'R, _: Default4) =
+        static member inline OfJson (_: 'R, _: Default6) =
             let codec = (^R : (static member JsonObjCodec : Codec<IReadOnlyDictionary<string,JsonValue>,'R>) ())
             codec |> Codec.compose jsonObjToValueCodec |> fst : JsonValue -> ^R ParseResult
 
-        // static member inline OfJson (r: 'R, _:Default3) = Result.catch FailDecode.string << (^R : (static member FromJSON: ^R  -> (JsonValue -> Result< ^R, string>)) r) : JsonValue ->  ^R ParseResult
-        // static member inline OfJson (_: 'R, _:Default2) = fun js -> Result.catch FailDecode.string (^R : (static member OfJson: JsonValue -> Result< ^R, string>) js) : ^R ParseResult
+        static member inline OfJson (r: 'R, _:Default5) = Result.catch (Error << DecodeError.Uncategorized) << (^R : (static member FromJSON: ^R  -> (JsonValue -> Result< ^R, string>)) r) : JsonValue ->  ^R ParseResult
+        static member inline OfJson (_: 'R, _:Default4) = fun js -> Result.catch (Error << DecodeError.Uncategorized) (^R : (static member OfJson: JsonValue -> Result< ^R, string>) js) : ^R ParseResult
         static member inline OfJson (r: 'R, _: Default3) = (^R : (static member FromJSON: ^R  -> (JsonValue -> ^R ParseResult)) r) : JsonValue ->  ^R ParseResult
         static member inline OfJson (_: 'R, _: Default2) = fun js -> (^R : (static member OfJson: JsonValue -> ^R ParseResult) js) : ^R ParseResult
 

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -289,11 +289,11 @@ module SystemJson =
 
         #if FSHARPDATA
 
-        let inline tryRead s = 
-            function
+        let inline tryRead x =
+            match x with
             | JsonValue.Number n -> Success (explicit n)
             | JsonValue.Float  n -> Success (explicit n)
-            | js                 -> Error (JsonTypeMismatch (s, js, JType.Number, getJType js))
+            | js                 -> FailDecode.numExpected js
 
         type JsonHelpers with
             static member jsonObjectOfJson = function
@@ -304,14 +304,14 @@ module SystemJson =
 
         #if NEWTONSOFT
 
-        let inline tryRead<'a> s =
-            function
+        let inline tryRead<'a> x =
+            match x with
             | JNumber j -> 
                 try
                   Success (j.ToObject<'a> ())
                 with
-                | e -> Error (InvalidValue (s, j, Some (string e)))
-            | js -> Error (JsonTypeMismatch (s, js, JType.Number, getJType js))
+                | e -> FailDecode.invalidValue j (Some (string e))
+            | js -> FailDecode.numExpected js
 
         type JsonHelpers with
             static member jsonObjectOfJson =
@@ -325,12 +325,13 @@ module SystemJson =
 
         #if SYSTEMJSON
 
-        let inline tryRead s = function
+        let inline tryRead x =
+            match x with
             | JNumber j ->
                 try
                     Success (implicit j)
-                with e -> Error (InvalidValue (s, j, Some (string e)))
-            | js -> Error (JsonTypeMismatch (s, js, JType.Number, getJType js))
+                with e -> FailDecode.invalidValue j (Some (string e))
+            | js -> FailDecode.numExpected js
 
         type JsonHelpers with
             static member inline jsonObjectOfJson =
@@ -468,17 +469,17 @@ module SystemJson =
                 else tuple7 <!> decoder1 a.[0] <*> decoder2 a.[1] <*> decoder3 a.[2] <*> decoder4 a.[3] <*> decoder5 a.[4] <*> decoder6 a.[5] <*> decoder7 a.[6]
             | a -> FailDecode.arrExpected a
         
-        let decimal x = tryRead<decimal> typeof<decimal> x
-        let int16   x = tryRead<int16>   typeof<int16>   x
-        let int     x = tryRead<int>     typeof<int>     x
-        let int64   x = tryRead<int64>   typeof<int64>   x
-        let uint16  x = tryRead<uint16>  typeof<uint16>  x
-        let uint32  x = tryRead<uint32>  typeof<uint32>  x
-        let uint64  x = tryRead<uint64>  typeof<uint64>  x
-        let byte    x = tryRead<byte>    typeof<byte>    x
-        let sbyte   x = tryRead<sbyte>   typeof<sbyte>   x
-        let float   x = tryRead<double>  typeof<double>  x
-        let float32 x = tryRead<single>  typeof<single>  x
+        let decimal x = tryRead<decimal> x
+        let int16   x = tryRead<int16>   x
+        let int     x = tryRead<int>     x
+        let int64   x = tryRead<int64>   x
+        let uint16  x = tryRead<uint16>  x
+        let uint32  x = tryRead<uint32>  x
+        let uint64  x = tryRead<uint64>  x
+        let byte    x = tryRead<byte>    x
+        let sbyte   x = tryRead<sbyte>   x
+        let float   x = tryRead<double>  x
+        let float32 x = tryRead<single>  x
 
         let boolean x =
             match x with

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -236,6 +236,7 @@ module SystemJson =
         | InvalidValue of System.Type * JsonValue * option<string>
         | PropertyNotFound of string * IReadOnlyDictionary<string, JsonValue>
         | ParseError of System.Type * exn * string
+        | Uncategorized of string
         | Multiple of DecodeError list
 
     with
@@ -251,6 +252,7 @@ module SystemJson =
             | InvalidValue (t, v, s) -> sprintf "Value %s is invalid for %s%s" (string v) (string t) (s |> Option.map (fun x -> " " + x) |> Option.defaultValue "")
             | PropertyNotFound (p, o) -> sprintf "Property: '%s' not found in object '%s'" p (string o)
             | ParseError (t, s, v) -> sprintf "Error decoding %s from  %s: %s" (string v) (string t) (string s)
+            | Uncategorized str -> str
             | Multiple lst -> List.map string lst |> String.concat "\r\n"
 
     type 'a ParseResult = Result<'a, DecodeError>

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -376,7 +376,7 @@ module SystemJson =
         let inline compose codec1 codec2 = 
             let (dec1, enc1) = codec1
             let (dec2, enc2) = codec2
-            (dec1 >> Result.bind dec2, enc1 << enc2)
+            (dec1 >> (=<<) dec2, enc1 << enc2)
 
         let decode (d: Decoder<'i, 'a>, _) (i: 'i) : ParseResult<'a> = d i
         let encode (_, e: Encoder<'o, 'a>) (a: 'a) : 'o = e a

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -260,6 +260,11 @@ module SystemJson =
     type 'a ParseResult = Result<'a, DecodeError>
 
     module Decode =
+        let inline Success x = Ok x
+        let (|Success|Failure|) = function
+            | Ok    x -> Success x
+            | Error x -> Failure x
+
         module Fail =
             let inline objExpected  v : Result<'t, _> = let a = getJType v in Error (JsonTypeMismatch (typeof<'t>, v, JType.Object, a))
             let inline arrExpected  v : Result<'t, _> = let a = getJType v in Error (JsonTypeMismatch (typeof<'t>, v, JType.Array , a))

--- a/IntegrationCompilationTests/Library.fs
+++ b/IntegrationCompilationTests/Library.fs
@@ -20,7 +20,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonFSharpData.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
     static member ToJson (x:PersonFSharpData) =
         jobj [ 
@@ -42,7 +42,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonNewtonsoft.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
     static member ToJson (x: PersonNewtonsoft) =
         jobj [ 
@@ -64,7 +64,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonSystemJson.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
     static member ToJson (x: PersonSystemJson) =
         jobj [ 

--- a/IntegrationCompilationTests/Library.fs
+++ b/IntegrationCompilationTests/Library.fs
@@ -20,7 +20,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonFSharpData.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected typeof<Person> x
+        | x -> Helpers.FailDecode.objExpected x
 
     static member ToJson (x:PersonFSharpData) =
         jobj [ 
@@ -42,7 +42,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonNewtonsoft.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected typeof<Person> x
+        | x -> Helpers.FailDecode.objExpected x
 
     static member ToJson (x: PersonNewtonsoft) =
         jobj [ 
@@ -64,7 +64,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonSystemJson.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Helpers.FailDecode.objExpected typeof<Person> x
+        | x -> Helpers.FailDecode.objExpected x
 
     static member ToJson (x: PersonSystemJson) =
         jobj [ 

--- a/IntegrationCompilationTests/Library.fs
+++ b/IntegrationCompilationTests/Library.fs
@@ -20,7 +20,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonFSharpData.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Error (sprintf "Expected person, found %A" x)
+        | x -> Helpers.FailDecode.objExpected typeof<Person> x
 
     static member ToJson (x:PersonFSharpData) =
         jobj [ 
@@ -42,7 +42,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonNewtonsoft.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Error (sprintf "Expected person, found %A" x)
+        | x -> Helpers.FailDecode.objExpected typeof<Person> x
 
     static member ToJson (x: PersonNewtonsoft) =
         jobj [ 
@@ -64,7 +64,7 @@ with
     static member OfJson json =
         match json with
         | JObject o -> PersonSystemJson.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Error (sprintf "Expected person, found %A" x)
+        | x -> Helpers.FailDecode.objExpected typeof<Person> x
 
     static member ToJson (x: PersonSystemJson) =
         jobj [ 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ type Person with
             let age = o .@ "age"
             let children = o .@ "children"
             match name, age, children with
-            | Success name, Success age, Success children -> 
-                Success {
+            | Ok name, Ok age, Ok children -> 
+                Ok {
                     Person.Name = name
                     Age = age
                     Children = children
@@ -76,7 +76,7 @@ type Person with
             | x -> Failure (sprintf "Error parsing person: %A" x)
         | x -> Failure (sprintf "Expected person, found %A" x)
         
-let john : Person ParseResult = parseJson """{"name": "John", "age": 44, "children": [{"name": "Katy", "age": 5, "children": []}, {"name": "Johnny", "age": 7, "children": []}]}"""        
+let john : Person ParseResult = parseJson """{"name": "John", "age": 44, "children": [{"name": "Katy", "age": 5, "children": []}, {"name": "Johnny", "age": 7, "children": []}]}"""
 ```
 
 Though it's much easier to do this in a monadic or applicative way. For example, using [FSharpPlus](https://github.com/fsprojects/FSharpPlus) (which is already a dependency of Fleece):

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ type Person with
                     Age = age
                     Children = children
                 }
-            | x -> Failure (sprintf "Error parsing person: %A" x)
-        | x -> Failure (sprintf "Expected person, found %A" x)
+            | x -> Error <| Uncategorized (sprintf "Error parsing person: %A" x)
+        | x -> FailDecode.objExpected typeof<Person> x
         
 let john : Person ParseResult = parseJson """{"name": "John", "age": 44, "children": [{"name": "Katy", "age": 5, "children": []}, {"name": "Johnny", "age": 7, "children": []}]}"""
 ```
@@ -90,7 +90,7 @@ type Person with
     static member OfJson json =
         match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Failure (sprintf "Expected person, found %A" x)
+        | x -> FailDecode.objExpected typeof<Person> x
 
 ```
 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -42,7 +42,7 @@ type Person with
     static member OfJson json = 
         match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
     static member ToJson (x: Person) =
         jobj [ 
@@ -65,7 +65,7 @@ type Attribute with
             monad {
                 let! name = o .@ "name"
                 if name = null then 
-                    return! FailDecode.nullString
+                    return! Decode.Fail.nullString
                 else
                     let! value = o .@ "value"
                     return {
@@ -73,7 +73,7 @@ type Attribute with
                         Value = value
                     }
             }
-        | x -> FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
     static member ToJson (x: Attribute) =
         jobj [ "name" .= x.Name; "value" .= x.Value ]
@@ -108,7 +108,7 @@ type NestedItem with
                     Availability = availability
                 }
             }
-        | x -> FailDecode.objExpected x
+        | x -> Decode.Fail.objExpected x
 
 type Name = {FirstName: string; LastName: string} with
     static member ToJson x = toJson (x.LastName + ", " + x.FirstName)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -65,7 +65,7 @@ type Attribute with
             monad {
                 let! name = o .@ "name"
                 if name = null then 
-                    return! FailDecode.nullString typeof<Attribute>
+                    return! FailDecode.nullString ()
                 else
                     let! value = o .@ "value"
                     return {

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -42,7 +42,7 @@ type Person with
     static member OfJson json = 
         match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> Failure (sprintf "Expected person, found %A" x)
+        | x -> FailDecode.objExpected typeof<Person> x
 
     static member ToJson (x: Person) =
         jobj [ 
@@ -65,7 +65,7 @@ type Attribute with
             monad {
                 let! name = o .@ "name"
                 if name = null then 
-                    return! Failure "Attribute name was null"
+                    return! FailDecode.nullString typeof<Attribute>
                 else
                     let! value = o .@ "value"
                     return {
@@ -73,7 +73,7 @@ type Attribute with
                         Value = value
                     }
             }
-        | x -> Failure (sprintf "Expected Attribute, found %A" x)
+        | x -> FailDecode.objExpected typeof<Attribute> x
 
     static member ToJson (x: Attribute) =
         jobj [ "name" .= x.Name; "value" .= x.Value ]
@@ -108,7 +108,7 @@ type NestedItem with
                     Availability = availability
                 }
             }
-        | x -> Failure (sprintf "Expected Item, found %A" x)
+        | x -> FailDecode.objExpected typeof<Item> x
         
 let strCleanUp x = System.Text.RegularExpressions.Regex.Replace(x, @"\s|\r\n?|\n", "")
 type Assert with
@@ -221,7 +221,7 @@ let tests = [
             test "decimal" {
             #if FSHARPDATA
                 let actual : int ParseResult = parseJson "2.1"
-                Assert.Equal("decimal", Failure (), Result.mapError (fun _-> ()) actual)
+                Assert.Equal("decimal", Error (), Result.mapError (fun _-> ()) actual)
             #else
                 let actual : int ParseResult = parseJson "2.1"
                 Assert.Equal("decimal", Success 2, actual)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -65,7 +65,7 @@ type Attribute with
             monad {
                 let! name = o .@ "name"
                 if name = null then 
-                    return! FailDecode.nullString ()
+                    return! FailDecode.nullString
                 else
                     let! value = o .@ "value"
                     return {

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -347,7 +347,8 @@ let tests = [
                 let actual =
                     match x with
                     | Error (ParseError _) -> "ParseError"
-                    | s -> string s
+                    | Error s -> string s
+                    | Ok s -> string s 
                 Assert.Equal ("Expecting a ParseError (since age is missing quotes)", "ParseError", actual)
             }
             test "PropertyNotFound" {

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -42,7 +42,7 @@ type Person with
     static member OfJson json = 
         match json with
         | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "children")
-        | x -> FailDecode.objExpected typeof<Person> x
+        | x -> FailDecode.objExpected x
 
     static member ToJson (x: Person) =
         jobj [ 
@@ -73,7 +73,7 @@ type Attribute with
                         Value = value
                     }
             }
-        | x -> FailDecode.objExpected typeof<Attribute> x
+        | x -> FailDecode.objExpected x
 
     static member ToJson (x: Attribute) =
         jobj [ "name" .= x.Name; "value" .= x.Value ]
@@ -108,7 +108,7 @@ type NestedItem with
                     Availability = availability
                 }
             }
-        | x -> FailDecode.objExpected typeof<Item> x
+        | x -> FailDecode.objExpected x
 
 type Name = {FirstName: string; LastName: string} with
     static member ToJson x = toJson (x.LastName + ", " + x.FirstName)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -342,14 +342,14 @@ let tests = [
 
         testList "Errors" [
             test "ParseError" {
-                let js = """{age: 42, "children": [], "name": "John"}"""
+                let js = """{"age" 42, "children": [], "name": "John"}"""
                 let x = parseJson<Person> js
                 let actual =
                     match x with
                     | Error (ParseError _) -> "ParseError"
                     | Error s -> string s
                     | Ok s -> string s 
-                Assert.Equal ("Expecting a ParseError (since age is missing quotes)", "ParseError", actual)
+                Assert.Equal ("Expecting a ParseError (since age is missing :)", "ParseError", actual)
             }
             test "PropertyNotFound" {
                 let js = """{"ageeee": 42, "children": [], "name": "John"}"""


### PR DESCRIPTION
This will allow us to react on errors, otherwise in order to be able to do that we would end up having to parse strings.

This doesn't come at no cost, my first concern is that it would break straight-forward codec composing.
In order to compose codecs, we will have to make sure the error type is the same (typically a string).

However, we can make it easy to transform to strings, also we can make sure this change is backwards compatible by adding some specific overloads accepting a string (but we might have to add a generic case in the DU).

Tests must be added to ensure the desired level of compatibility.