### PR TITLE
Applicative / Alternative codec

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -367,11 +367,11 @@ module SystemJson =
     /// A codec for raw type 'S to strong type 't.
     type Codec<'S, 't> = Codec<'S, 'S, 't>
 
-    type ConcreteCodec<'S1, 'S2, 't1, 't2> = { Decoder : Decoder<'S1, 't1>; Encoder : Encoder<'S2, 't2> } with
-        static member inline Return f = { Decoder = (fun _ -> Success f); Encoder = zero }
+    type ConcreteCodec<'S1, 'S2, 't1, 't2> = { Decoder : ReaderT<'S1, ParseResult<'t1>>; Encoder : Encoder<'S2, 't2> } with
+        static member inline Return f = { Decoder = result f; Encoder = zero }
         static member inline (<*>) (remainderFields: ConcreteCodec<'S, 'S, 'f ->'r, 'T>, currentField: ConcreteCodec<'S, 'S, 'f, 'T>) =
             {
-                Decoder = Compose.run (Compose (remainderFields.Decoder : Decoder<'S, 'f -> 'r>) <*> Compose (currentField.Decoder))
+                Decoder = (remainderFields.Decoder : ReaderT<'S, ParseResult<'f -> 'r>>) <*> currentField.Decoder
                 Encoder = remainderFields.Encoder ++ currentField.Encoder
             }
 
@@ -389,8 +389,8 @@ module SystemJson =
         let decode (d: Decoder<'i, 'a>, _) (i: 'i) : ParseResult<'a> = d i
         let encode (_, e: Encoder<'o, 'a>) (a: 'a) : 'o = e a
 
-        let ofConcrete {Decoder = d; Encoder = e} = d, e
-        let toConcrete (d, e) = {Decoder = d; Encoder = e}
+        let ofConcrete {Decoder = ReaderT d; Encoder = e} = d, e
+        let toConcrete (d, e) = {Decoder = ReaderT d; Encoder = e}
 
     let jsonObjToValueCodec = ((function JObject (o: IReadOnlyDictionary<_,_>) -> Ok o | a  -> Decode.Fail.objExpected a) , JObject)
     let jsonValueToTextCodec = (fun x -> try Ok (JsonValue.Parse x) with e -> Decode.Fail.parseError e x), (fun (x: JsonValue) -> string x)

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -993,20 +993,57 @@ module SystemJson =
             | Some (KeyValue(_, value)) -> ofJson value
             | _                         -> Decode.Fail.propertyNotFound key (ofList o)
 
-        /// Gets a value from a Json object
-        let inline jgetFromList (o: list<KeyValuePair<string, JsonValue>>) key = jgetFromListWith ofJson o key
+        // /// Gets a value from a Json object
+        // let inline jgetFromList (o: list<KeyValuePair<string, JsonValue>>) key = jgetFromListWith ofJson o key
 
-        let inline tag    (name: string) (cons: 'param -> 'T) (getter: 'T -> 'param option) =
+        /// Tries to get a value from a Json object.
+        /// Returns None if key is not present in the object.
+        let inline jgetFromListOptWith ofJson (o: list<KeyValuePair<string, JsonValue>>) key =
+            match List.tryFind (fun (KeyValue(x, _)) -> x = key) o with
+            | Some (KeyValue(_, value)) -> ofJson value |> map Some
+            | _ -> Success None
+
+        let inline reqWith codec prop getter =
             {
-                Decoder = (ReaderT (fun (json: KeyValuePair<string,JsonValue> list) -> (cons <!> jgetFromList json name)))
-                Encoder = fun x -> Const (match getter x with Some v -> [KeyValuePair (name, toJson v)] | _ -> [])
+                Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListWith (fst codec) o prop)
+                Encoder = (getter >> fun (x: 'Value) -> Const [KeyValuePair (prop, (snd codec) x)])
+            }
+
+        let inline optWith codec prop getter =
+            {
+                Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListOptWith (fst codec) o prop)
+                Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
             }
 
         /// Derives a concrete field codec for a required field
-        let inline req a b = deriveFieldCodec jsonValueCodec a b |> Codec.toConcrete
+        let inline req prop getter = reqWith jsonValueCodec prop getter
 
         /// Derives a concrete field codec for an optional field
-        let inline opt a b = deriveFieldCodecOpt jsonValueCodec a b |> Codec.toConcrete
+        let inline opt prop getter = optWith jsonValueCodec prop getter
+
+        let inline regWith codec (prop: string) (getter: 'T -> 'Value option) =
+            {
+                Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListWith (fst codec) o prop)
+                Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
+            }
+
+        let inline reg (name: string) (getter: 'T -> 'param option) = regWith jsonValueCodec name getter
+
+        let inline tagWith codec (cons: 'Value -> 'T) (prop: string) (getter: 'T -> 'Value option) =
+            {
+                Decoder = ReaderT (fun (o: KeyValuePair<string,JsonValue> list) -> cons <!> jgetFromListWith (fst codec) o prop)
+                Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
+            }
+
+        let inline tag (cons: 'param -> 'T) (name: string) (getter: 'T -> 'param option) = tagWith jsonValueCodec cons name getter
+
+
+
+        /// Derives a concrete field codec for a required field
+        let inline _req a b = deriveFieldCodec jsonValueCodec a b |> Codec.toConcrete
+
+        /// Derives a concrete field codec for an optional field
+        let inline _opt a b = deriveFieldCodecOpt jsonValueCodec a b |> Codec.toConcrete
 
     module Lens =
         open FSharpPlus.Lens

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -993,23 +993,23 @@ module SystemJson =
             | Some (KeyValue(_, value)) -> ofJson value |> map Some
             | _ -> Success None
 
-        let inline optWith codec prop getter =
+        let inline joptWith codec prop getter =
             {
                 Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListOptWith (fst codec) o prop)
                 Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
             }
 
         /// Derives a concrete field codec for an optional field
-        let inline opt prop getter = optWith jsonValueCodec prop getter
+        let inline jopt prop getter = joptWith jsonValueCodec prop getter
 
-        let inline reqWith codec (prop: string) (getter: 'T -> 'Value option) =
+        let inline jreqWith codec (prop: string) (getter: 'T -> 'Value option) =
             {
                 Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListWith (fst codec) o prop)
                 Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
             }
 
         /// Derives a concrete field codec for a required field
-        let inline req (name: string) (getter: 'T -> 'param option) = reqWith jsonValueCodec name getter
+        let inline jreq (name: string) (getter: 'T -> 'param option) = jreqWith jsonValueCodec name getter
 
         let inline jchoice (codecs: seq<ConcreteCodec<'S, 'S, 't1, 't2>>) =
             let head, tail = Seq.head codecs, Seq.tail codecs

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -1038,6 +1038,9 @@ module SystemJson =
 
         let inline tag (cons: 'param -> 'T) (name: string) (getter: 'T -> 'param option) = tagWith jsonValueCodec cons name getter
 
+        let inline jchoice (codecs: seq<ConcreteCodec<'S, 'S, 't1, 't2>>) =
+            let head, tail = Seq.head codecs, Seq.tail codecs
+            foldBack (<|>) tail head
 
 
         /// Derives a concrete field codec for a required field

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -1004,39 +1004,23 @@ module SystemJson =
             | Some (KeyValue(_, value)) -> ofJson value |> map Some
             | _ -> Success None
 
-        let inline reqWith codec prop getter =
-            {
-                Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListWith (fst codec) o prop)
-                Encoder = (getter >> fun (x: 'Value) -> Const [KeyValuePair (prop, (snd codec) x)])
-            }
-
         let inline optWith codec prop getter =
             {
                 Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListOptWith (fst codec) o prop)
                 Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
             }
 
-        /// Derives a concrete field codec for a required field
-        let inline req prop getter = reqWith jsonValueCodec prop getter
-
         /// Derives a concrete field codec for an optional field
         let inline opt prop getter = optWith jsonValueCodec prop getter
 
-        let inline regWith codec (prop: string) (getter: 'T -> 'Value option) =
+        let inline reqWith codec (prop: string) (getter: 'T -> 'Value option) =
             {
                 Decoder = ReaderT (fun (o: list<KeyValuePair<string, JsonValue>>) -> jgetFromListWith (fst codec) o prop)
                 Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
             }
 
-        let inline reg (name: string) (getter: 'T -> 'param option) = regWith jsonValueCodec name getter
-
-        let inline tagWith codec (cons: 'Value -> 'T) (prop: string) (getter: 'T -> 'Value option) =
-            {
-                Decoder = ReaderT (fun (o: KeyValuePair<string,JsonValue> list) -> cons <!> jgetFromListWith (fst codec) o prop)
-                Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [KeyValuePair (prop, (snd codec) x)] | _ -> [])
-            }
-
-        let inline tag (cons: 'param -> 'T) (name: string) (getter: 'T -> 'param option) = tagWith jsonValueCodec cons name getter
+        /// Derives a concrete field codec for a required field
+        let inline req (name: string) (getter: 'T -> 'param option) = reqWith jsonValueCodec name getter
 
         let inline jchoice (codecs: seq<ConcreteCodec<'S, 'S, 't1, 't2>>) =
             let head, tail = Seq.head codecs, Seq.tail codecs

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -241,7 +241,7 @@ module SystemJson =
         | Multiple of DecodeError list
 
     with
-        static member (+) (x, y) = 
+        static member (+) (x, y) =
             match x, y with
             | Multiple x, Multiple y -> Multiple (x @ y)
             | _                      -> Multiple [x; y]
@@ -374,6 +374,7 @@ module SystemJson =
                 Decoder = (remainderFields.Decoder : ReaderT<'S, ParseResult<'f -> 'r>>) <*> currentField.Decoder
                 Encoder = fun w -> (remainderFields.Encoder w *> currentField.Encoder w)
             }
+        static member inline (<!>) (f, field: ConcreteCodec<'S, 'S, 'f, 'T>) = f <!> field
         static member inline (<|>) (source: ConcreteCodec<'S, 'S, 'f, 'T>, alternative: ConcreteCodec<'S, 'S, 'f, 'T>) =
             {
                 Decoder = (source.Decoder : ReaderT<'S, ParseResult<'f>>) <|> alternative.Decoder
@@ -689,7 +690,7 @@ module SystemJson =
         static member inline OfJson (_: Dictionary<string, 'a>, _: OfJson) : JsonValue -> ParseResult<Dictionary<string, 'a>> = JsonDecode.dictionary  OfJson.Invoke
         static member inline OfJson (_: ResizeArray<'a>       , _: OfJson) : JsonValue -> ParseResult<ResizeArray<'a>>        = JsonDecode.resizeArray OfJson.Invoke
         static member inline OfJson (_: 'a Id1, _: OfJson) : JsonValue -> ParseResult<Id1<'a>> = fun _ -> Success (Id1<'a> Unchecked.defaultof<'a>)
-        static member inline OfJson (_: 'a Id2, _: OfJson) : JsonValue -> ParseResult<Id2<'a>> = fun _ -> Success (Id2<'a> Unchecked.defaultof<'a>)    
+        static member inline OfJson (_: 'a Id2, _: OfJson) : JsonValue -> ParseResult<Id2<'a>> = fun _ -> Success (Id2<'a> Unchecked.defaultof<'a>)
 
     type OfJson with
         static member inline OfJson (_: 'a * 'b, _: OfJson) : JsonValue -> ParseResult<'a * 'b> = JsonDecode.tuple2 OfJson.Invoke OfJson.Invoke

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -848,6 +848,12 @@ module SystemJson =
             fun p -> combiner (snd remainderFields p) ((snd currentField) p)
         )
 
+    let inline deriveFieldCodec codec prop getter =
+        (
+            (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetWith (fst codec) o prop),
+            (getter >> fun (x: 'Value) -> dict [prop, (snd codec) x])
+        )
+
     /// <summary>Appends a field mapping to the codec.</summary>
     /// <param name="codec">The codec to be used.</param>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -855,12 +861,7 @@ module SystemJson =
     /// <param name="rest">The other mappings.</param>
     /// <returns>The resulting object codec.</returns>
     let inline jfieldWith codec fieldName (getter: 'T -> 'Value) (rest: SplitCodec<_, _ -> 'Rest, _>) =
-        let inline deriveFieldCodec prop getter =
-            (
-                (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetWith (fst codec) o prop),
-                (getter >> fun (x: 'Value) -> dict [prop, (snd codec) x])
-            )
-        diApply IReadOnlyDictionary.union rest (deriveFieldCodec fieldName getter)
+        diApply IReadOnlyDictionary.union rest (deriveFieldCodec codec fieldName getter)
 
     /// <summary>Appends a field mapping to the codec.</summary>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -869,6 +870,12 @@ module SystemJson =
     /// <returns>The resulting object codec.</returns>
     let inline jfield fieldName (getter: 'T -> 'Value) (rest: SplitCodec<_, _ -> 'Rest, _>) = jfieldWith jsonValueCodec fieldName getter rest
 
+    let inline deriveFieldCodecOpt codec prop getter =
+        (
+            (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetOptWith (fst codec) o prop),
+            (getter >> function Some (x: 'Value) -> dict [prop, (snd codec) x] | _ -> dict [])
+        )
+
     /// <summary>Appends an optional field mapping to the codec.</summary>
     /// <param name="codec">The codec to be used.</param>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -876,12 +883,7 @@ module SystemJson =
     /// <param name="rest">The other mappings.</param>
     /// <returns>The resulting object codec.</returns>
     let inline jfieldOptWith codec fieldName (getter: 'T -> 'Value option) (rest: SplitCodec<_, _ -> 'Rest, _>) =
-        let inline deriveFieldCodecOpt prop getter =
-            (
-                (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetOptWith (fst codec) o prop),
-                (getter >> function Some (x: 'Value) -> dict [prop, (snd codec) x] | _ -> dict [])
-            )
-        diApply IReadOnlyDictionary.union rest (deriveFieldCodecOpt fieldName getter)
+        diApply IReadOnlyDictionary.union rest (deriveFieldCodecOpt codec fieldName getter)
 
     /// <summary>Appends an optional field mapping to the codec.</summary>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -906,12 +908,18 @@ module SystemJson =
         /// Returns None if key is not present in the object.
         let inline (.@?) o key = jgetOpt o key
         
-        /// <summary>Appends a field mapping to the codec.</summary>
+        /// <summary>Applies a field mapping to the object codec.</summary>
         /// <param name="fieldName">A string that will be used as key to the field.</param>
         /// <param name="getter">The field getter function.</param>
         /// <param name="rest">The other mappings.</param>
         /// <returns>The resulting object codec.</returns>
         let inline (<*/>) (rest: SplitCodec<_, _->'Rest, _>) (fieldName, getter: 'T -> 'Value) = jfield fieldName getter rest
+
+        /// <summary>Applies a field codec to the object codec.</summary>
+        /// <param name="rest">The codec for the other fields.</param>
+        /// <param name="field">The current field codec.</param>
+        /// <returns>The resulting object codec.</returns>
+        let inline (<**>) (rest: SplitCodec<_, _->'Rest, _>) field = diApply IReadOnlyDictionary.union rest field
 
         /// <summary>Appends the first field mapping to the codec.</summary>
         /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -919,6 +927,12 @@ module SystemJson =
         /// <param name="f">An object initializer as a curried function.</param>
         /// <returns>The resulting object codec.</returns>
         let inline (<!/>) f (fieldName, getter: 'T -> 'Value) = jfield fieldName getter (withFields f)
+
+        /// <summary>Appends a field codec to an object initializer lifted as a codec.</summary>
+        /// <param name="f">A curried object initializer.</param>
+        /// <param name="field">The current field codec.</param>
+        /// <returns>The resulting object codec.</returns>
+        let inline (<!!>) f field = diApply IReadOnlyDictionary.union (withFields f) field
 
         /// <summary>Appends an optional field mapping to the codec.</summary>
         /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -936,6 +950,12 @@ module SystemJson =
 
         /// Tuple two values.
         let inline (^=) a b = (a, b)
+
+        /// Derives a field codec for a required field
+        let inline (^=@) a b = deriveFieldCodec jsonValueCodec a b
+
+        /// Derives a field codec for an optional field
+        let inline (^=@?) a b = deriveFieldCodecOpt jsonValueCodec a b
 
     module Lens =
         open FSharpPlus.Lens

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -368,11 +368,11 @@ module SystemJson =
     type Codec<'S, 't> = Codec<'S, 'S, 't>
 
     type ConcreteCodec<'S1, 'S2, 't1, 't2> = { Decoder : Decoder<'S1, 't1>; Encoder : Encoder<'S2, 't2> } with
-        static member inline Return f = { Decoder = (fun _ -> Success f); Encoder = (fun _ -> getZero()) }
+        static member inline Return f = { Decoder = (fun _ -> Success f); Encoder = zero }
         static member inline (<*>) (remainderFields: ConcreteCodec<'S, 'S, 'f ->'r, 'T>, currentField: ConcreteCodec<'S, 'S, 'f, 'T>) =
             {
                 Decoder = Compose.run (Compose (remainderFields.Decoder : Decoder<'S, 'f -> 'r>) <*> Compose (currentField.Decoder))
-                Encoder = fun p -> remainderFields.Encoder p ++ currentField.Encoder p
+                Encoder = remainderFields.Encoder ++ currentField.Encoder
             }
 
 

--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -888,12 +888,6 @@ module SystemJson =
             fun p -> combiner (snd remainderFields p) ((snd currentField) p)
         )
 
-    let inline deriveFieldCodec codec prop getter =
-        (
-            (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetWith (fst codec) o prop),
-            (getter >> fun (x: 'Value) -> dict [prop, (snd codec) x])
-        )
-
     /// <summary>Appends a field mapping to the codec.</summary>
     /// <param name="codec">The codec to be used.</param>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -901,6 +895,11 @@ module SystemJson =
     /// <param name="rest">The other mappings.</param>
     /// <returns>The resulting object codec.</returns>
     let inline jfieldWith codec fieldName (getter: 'T -> 'Value) (rest: SplitCodec<_, _ -> 'Rest, _>) =
+        let inline deriveFieldCodec codec prop getter =
+            (
+                (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetWith (fst codec) o prop),
+                (getter >> fun (x: 'Value) -> dict [prop, (snd codec) x])
+            )
         diApply IReadOnlyDictionary.union rest (deriveFieldCodec codec fieldName getter)
 
     /// <summary>Appends a field mapping to the codec.</summary>
@@ -910,12 +909,6 @@ module SystemJson =
     /// <returns>The resulting object codec.</returns>
     let inline jfield fieldName (getter: 'T -> 'Value) (rest: SplitCodec<_, _ -> 'Rest, _>) = jfieldWith jsonValueCodec fieldName getter rest
 
-    let inline deriveFieldCodecOpt codec prop getter =
-        (
-            (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetOptWith (fst codec) o prop),
-            (getter >> function Some (x: 'Value) -> dict [prop, (snd codec) x] | _ -> dict [])
-        )
-
     /// <summary>Appends an optional field mapping to the codec.</summary>
     /// <param name="codec">The codec to be used.</param>
     /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -923,6 +916,11 @@ module SystemJson =
     /// <param name="rest">The other mappings.</param>
     /// <returns>The resulting object codec.</returns>
     let inline jfieldOptWith codec fieldName (getter: 'T -> 'Value option) (rest: SplitCodec<_, _ -> 'Rest, _>) =
+        let inline deriveFieldCodecOpt codec prop getter =
+            (
+                (fun (o: IReadOnlyDictionary<string,JsonValue>) -> jgetOptWith (fst codec) o prop),
+                (getter >> function Some (x: 'Value) -> dict [prop, (snd codec) x] | _ -> dict [])
+            )
         diApply IReadOnlyDictionary.union rest (deriveFieldCodecOpt codec fieldName getter)
 
     /// <summary>Appends an optional field mapping to the codec.</summary>
@@ -955,24 +953,12 @@ module SystemJson =
         /// <returns>The resulting object codec.</returns>
         let inline (<*/>) (rest: SplitCodec<_, _->'Rest, _>) (fieldName, getter: 'T -> 'Value) = jfield fieldName getter rest
 
-        /// <summary>Applies a field codec to the object codec.</summary>
-        /// <param name="rest">The codec for the other fields.</param>
-        /// <param name="field">The current field codec.</param>
-        /// <returns>The resulting object codec.</returns>
-        let inline (<**>) (rest: SplitCodec<_, _->'Rest, _>) field = diApply IReadOnlyDictionary.union rest field
-
         /// <summary>Appends the first field mapping to the codec.</summary>
         /// <param name="fieldName">A string that will be used as key to the field.</param>
         /// <param name="getter">The field getter function.</param>
         /// <param name="f">An object initializer as a curried function.</param>
         /// <returns>The resulting object codec.</returns>
         let inline (<!/>) f (fieldName, getter: 'T -> 'Value) = jfield fieldName getter (withFields f)
-
-        /// <summary>Appends a field codec to an object initializer lifted as a codec.</summary>
-        /// <param name="f">A curried object initializer.</param>
-        /// <param name="field">The current field codec.</param>
-        /// <returns>The resulting object codec.</returns>
-        let inline (<!!>) f field = diApply IReadOnlyDictionary.union (withFields f) field
 
         /// <summary>Appends an optional field mapping to the codec.</summary>
         /// <param name="fieldName">A string that will be used as key to the field.</param>
@@ -990,12 +976,6 @@ module SystemJson =
 
         /// Tuple two values.
         let inline (^=) a b = (a, b)
-
-        /// Derives a field codec for a required field
-        let inline (^=@) a b = deriveFieldCodec jsonValueCodec a b
-
-        /// Derives a field codec for an optional field
-        let inline (^=@?) a b = deriveFieldCodecOpt jsonValueCodec a b
 
         /// Gets a value from a Json object
         let inline jgetFromListWith ofJson (o: list<KeyValuePair<string, JsonValue>>) key =

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -118,11 +118,12 @@ type Vehicle =
    | Van of make : string * capacity : float
 with
     static member JsonObjCodec =
-        (    Car              <!> reg "car"       (function (Car  x      ) -> Some  x     | _ -> None))
-        <|> (Van              <!> reg "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None))
-        <|> (MotorBike        <!> reg "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None))
-        <|> ((fun () -> Bike) <!> reg "bike"      (function  Bike          -> Some ()     | _ -> None))
-        |> Codec.ofConcrete
+        [
+            Car              <!> reg "car"       (function (Car  x      ) -> Some  x     | _ -> None)
+            Van              <!> reg "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
+            MotorBike        <!> reg "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None)
+            (fun () -> Bike) <!> reg "bike"      (function  Bike          -> Some ()     | _ -> None)
+        ] |> jchoice |> Codec.ofConcrete
 
 type Name = {FirstName: string; LastName: string} with
     static member ToJson x = toJson (x.LastName + ", " + x.FirstName)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -87,9 +87,10 @@ type Item = {
 type Item with
     static member JsonObjCodec =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
-        <!!>  "id"          ^=@  fun x -> x.Id
-        <**>  "brand"       ^=@  fun x -> x.Brand
-        <**> "availability" ^=@? fun x -> x.Availability
+        <!> req  "id"          (fun x -> x.Id          )
+        <*> req  "brand"       (fun x -> x.Brand       )
+        <*> opt "availability" (fun x -> x.Availability)
+        |> Codec.ofConcrete
 
 type NestedItem = NestedItem of Item
 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -91,7 +91,6 @@ type Item with
         <*> req  "brand"       (fun x -> x.Brand       )
         <*> opt "availability" (fun x -> x.Availability)
         |> Codec.ofConcrete
-        |> Codec.invmap FstDict FstDict.run
 
 type NestedItem = NestedItem of Item
 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -123,7 +123,7 @@ with
             Van              <!> req "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
             MotorBike        <!> req "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None)
             (fun () -> Bike) <!> req "bike"      (function  Bike          -> Some ()     | _ -> None)
-        ] |> jchoice |> Codec.ofConcrete
+        ] |> jchoice
 
 type Name = {FirstName: string; LastName: string} with
     static member ToJson x = toJson (x.LastName + ", " + x.FirstName)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -91,6 +91,7 @@ type Item with
         <*> req  "brand"       (fun x -> x.Brand       )
         <*> opt "availability" (fun x -> x.Availability)
         |> Codec.ofConcrete
+        |> Codec.invmap FstDict FstDict.run
 
 type NestedItem = NestedItem of Item
 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -87,9 +87,9 @@ type Item = {
 type Item with
     static member JsonObjCodec =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
-        <!/>  "id"           ^= fun x -> x.Id
-        <*/>  "brand"        ^= fun x -> x.Brand
-        <*/?> "availability" ^= fun x -> x.Availability
+        <!!>  "id"          ^=@  fun x -> x.Id
+        <**>  "brand"       ^=@  fun x -> x.Brand
+        <**> "availability" ^=@? fun x -> x.Availability
 
 type NestedItem = NestedItem of Item
 

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -87,8 +87,8 @@ type Item = {
 type Item with
     static member JsonObjCodec =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
-        <!> reg  "id"          (fun x -> Some x.Id     )
-        <*> reg  "brand"       (fun x -> Some x.Brand  )
+        <!> req  "id"          (fun x -> Some x.Id     )
+        <*> req  "brand"       (fun x -> Some x.Brand  )
         <*> opt "availability" (fun x -> x.Availability)
         |> Codec.ofConcrete
 
@@ -119,10 +119,10 @@ type Vehicle =
 with
     static member JsonObjCodec =
         [
-            Car              <!> reg "car"       (function (Car  x      ) -> Some  x     | _ -> None)
-            Van              <!> reg "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
-            MotorBike        <!> reg "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None)
-            (fun () -> Bike) <!> reg "bike"      (function  Bike          -> Some ()     | _ -> None)
+            Car              <!> req "car"       (function (Car  x      ) -> Some  x     | _ -> None)
+            Van              <!> req "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
+            MotorBike        <!> req "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None)
+            (fun () -> Bike) <!> req "bike"      (function  Bike          -> Some ()     | _ -> None)
         ] |> jchoice |> Codec.ofConcrete
 
 type Name = {FirstName: string; LastName: string} with

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -134,6 +134,7 @@ type Name = {FirstName: string; LastName: string} with
         | _ -> Error "Invalid Json Type"
         
 let strCleanUp x = System.Text.RegularExpressions.Regex.Replace(x, @"\s|\r\n?|\n", "")
+let strCleanUpAll x = System.Text.RegularExpressions.Regex.Replace(x, "\s|\r\n?|\n|\"|\\\\", "")
 type Assert with
     static member inline JSON(expected: string, value: 'a) =
         Assert.Equal("", expected, strCleanUp ((toJson value).ToString()))
@@ -326,16 +327,22 @@ let tests = [
             }
 
             test "Vehicle" {
-                let w = [ MotorBike ()      ] |> toJson |> string
-                let x = [ Car "Renault"     ] |> toJson |> string
-                let y = [ Van ("Fiat", 5.8) ] |> toJson |> string
-                let z = [ Bike              ] |> toJson |> string
+                let w = [ MotorBike ()      ] |> toJson |> string |> strCleanUpAll
+                let x = [ Car "Renault"     ] |> toJson |> string |> strCleanUpAll
+                let y = [ Van ("Fiat", 5.8) ] |> toJson |> string |> strCleanUpAll
+                let z = [ Bike              ] |> toJson |> string |> strCleanUpAll
             
-                let expectedW = """[{\"motorBike\":[]}]"""
-                let expectedX = """[{"car":"Renault"}]"""
-                let expectedY = """[{"van":["Fiat",5.8]}]"""
-                let expectedZ = """[{"bike":[]}]"""
-            
+                #if NEWTONSOFT
+                let expectedW = "[{motorBike:[]}]"
+                let expectedX = "[{car:Renault}]"
+                let expectedY = "[{van:[Fiat,5.8]}]"
+                let expectedZ = "[{bike:[]}]"
+                #else
+                let expectedW = "\"[{motorBike:[]}]\""
+                let expectedX = "\"[{car:Renault}]\""
+                let expectedY = "\"[{van:[Fiat,5.8]}]\""
+                let expectedZ = "\"[{bike:[]}]\""
+                #endif
                 Assert.JSON(expectedW, w)
                 Assert.JSON(expectedX, x)
                 Assert.JSON(expectedY, y)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -118,10 +118,10 @@ type Vehicle =
    | Van of make : string * capacity : float
 with
     static member JsonObjCodec =
-        tag     "car"       Car              (function (Car  x      ) -> Some  x     | _ -> None)
-        <|> tag "van"       Van              (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
-        <|> tag "motorBike" MotorBike        (function (MotorBike ()) -> Some ()     | _ -> None)
-        <|> tag "bike"      (fun () -> Bike) (function  Bike          -> Some ()     | _ -> None)
+        tag     Car              "car"       (function (Car  x      ) -> Some  x     | _ -> None)
+        <|> tag Van              "van"       (function (Van (x, y)  ) -> Some (x, y) | _ -> None)
+        <|> tag MotorBike        "motorBike" (function (MotorBike ()) -> Some ()     | _ -> None)
+        <|> tag (fun () -> Bike) "bike"      (function  Bike          -> Some ()     | _ -> None)
         |> Codec.ofConcrete
 
 type Name = {FirstName: string; LastName: string} with

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -353,21 +353,29 @@ let tests = [
                 let y = [ Truck ("Ford", 20.0)       ] |> toJson |> string |> strCleanUpAll
                 let z = [ Aircraft ("Airbus", 200.0) ] |> toJson |> string |> strCleanUpAll
             
-                #if NEWTONSOFT
-                let expectedU = "[{bike:[]}]"
-                let expectedV = "[{motorBike:[]}]"
-                let expectedW = "[{car:Renault}]"
-                let expectedX = "[{van:[Fiat,5.8]}]"
-                let expectedY = "[{truck:{make:Ford,capacity:20}}]"
-                let expectedZ = "[{aircraft:{make:Airbus,capacity:200}}]"
-                
-                #else
+                #if FSHARPDATA
                 let expectedU = "\"[{bike:[]}]\""
                 let expectedV = "\"[{motorBike:[]}]\""
                 let expectedW = "\"[{car:Renault}]\""
                 let expectedX = "\"[{van:[Fiat,5.8]}]\""
                 let expectedY = "\"[{truck:{make:Ford,capacity:20}}]\""
                 let expectedZ = "\"[{aircraft:{make:Airbus,capacity:200}}]\""
+                #endif
+                #if NEWTONSOFT
+                let expectedU = "[{bike:[]}]"
+                let expectedV = "[{motorBike:[]}]"
+                let expectedW = "[{car:Renault}]"
+                let expectedX = "[{van:[Fiat,5.8]}]"
+                let expectedY = "[{truck:{make:Ford,capacity:20.0}}]"
+                let expectedZ = "[{aircraft:{make:Airbus,capacity:200.0}}]"
+                #endif
+                #if SYSTEMJSON
+                let expectedU = "\"[{bike:[]}]\""
+                let expectedV = "\"[{motorBike:[]}]\""
+                let expectedW = "\"[{car:Renault}]\""
+                let expectedX = "\"[{van:[Fiat,5.8]}]\""
+                let expectedY = "\"[{truck:{capacity:20,make:Ford}}]\""
+                let expectedZ = "\"[{aircraft:{capacity:200,make:Airbus}}]\""
                 #endif
                 Assert.JSON(expectedU, u)
                 Assert.JSON(expectedV, v)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -87,9 +87,9 @@ type Item = {
 type Item with
     static member JsonObjCodec =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
-        <!> req  "id"          (fun x -> Some x.Id     )
-        <*> req  "brand"       (fun x -> Some x.Brand  )
-        <*> opt "availability" (fun x -> x.Availability)
+        <!> jreq  "id"          (fun x -> Some x.Id     )
+        <*> jreq  "brand"       (fun x -> Some x.Brand  )
+        <*> jopt "availability" (fun x -> x.Availability)
         |> Codec.ofConcrete
 
 type NestedItem = NestedItem of Item
@@ -130,18 +130,18 @@ type Vehicle =
 with
     static member JsonObjCodec =
         [
-            (fun () -> Bike) <!> req "bike"      (function  Bike             -> Some ()     | _ -> None)
-            MotorBike        <!> req "motorBike" (function (MotorBike ()   ) -> Some ()     | _ -> None)
-            Car              <!> req "car"       (function (Car  x         ) -> Some  x     | _ -> None)
-            Van              <!> req "van"       (function (Van (x, y)     ) -> Some (x, y) | _ -> None)
+            (fun () -> Bike) <!> jreq "bike"      (function  Bike             -> Some ()     | _ -> None)
+            MotorBike        <!> jreq "motorBike" (function (MotorBike ()   ) -> Some ()     | _ -> None)
+            Car              <!> jreq "car"       (function (Car  x         ) -> Some  x     | _ -> None)
+            Van              <!> jreq "van"       (function (Van (x, y)     ) -> Some (x, y) | _ -> None)
             tag "truck" (
                 (fun m c -> Truck (make = m, capacity = c))
-                    <!> req  "make"     (function (Truck (make     = x)) -> Some  x | _ -> None)
-                    <*> req  "capacity" (function (Truck (capacity = x)) -> Some  x | _ -> None))
+                    <!> jreq  "make"     (function (Truck (make     = x)) -> Some  x | _ -> None)
+                    <*> jreq  "capacity" (function (Truck (capacity = x)) -> Some  x | _ -> None))
             tag "aircraft" (
                 (fun m c -> Aircraft (make = m, capacity = c))
-                    <!> req  "make"     (function (Aircraft (make     = x)) -> Some  x | _ -> None)
-                    <*> req  "capacity" (function (Aircraft (capacity = x)) -> Some  x | _ -> None))
+                    <!> jreq  "make"     (function (Aircraft (make     = x)) -> Some  x | _ -> None)
+                    <*> jreq  "capacity" (function (Aircraft (capacity = x)) -> Some  x | _ -> None))
         ] |> jchoice
 
 type Name = {FirstName: string; LastName: string} with


### PR DESCRIPTION
- [x] Define a concrete codec type
- [x] Add an applicative instance
- [x] Write some combinators for required and optional fields
- [x] Figure out existing or new combinators for alternatives, in order to codec DUs
- [x] Explore a variant of `choice` that works assuming a non-empty list
- [x] Find out a codec for Singleton DUs (not worth, single tag DUs have to be a prop list in order to fold)
- [x] Think about the existing codec alias (as tuple), especially the parameter for the `With` functions: I think we can decide this in a different PR/issue, for now we can keep back compatibility
- [x] Create tests for all scenarios
- [x] Update the docs